### PR TITLE
Fix quiz visibility filter

### DIFF
--- a/app/[lng]/admin/quizzes/create/page.tsx
+++ b/app/[lng]/admin/quizzes/create/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "../../../../../components/ui/card";
+import { Button } from "../../../../../components/ui/button";
+import { Input } from "../../../../../components/ui/input";
+import { Textarea } from "../../../../../components/ui/textarea";
+import { Checkbox } from "../../../../../components/ui/checkbox";
+import { ShieldCheck } from "lucide-react";
+
+interface User { _id: string; isAdmin: boolean }
+
+export default function CreateQuiz() {
+  const { data: session } = useSession();
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [category, setCategory] = useState("");
+  const [subCategory, setSubCategory] = useState("");
+  const [difficulty, setDifficulty] = useState("beginner");
+  const [language, setLanguage] = useState("en");
+  const [isPublic, setIsPublic] = useState(true);
+  const [isPremium, setIsPremium] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!session) {
+        router.push("/api/auth/signin");
+        return;
+      }
+      try {
+        const res = await fetch("/api/user");
+        if (res.ok) {
+          const data = await res.json();
+          setUser(data.user);
+          if (!data.user.isAdmin) {
+            router.push("/");
+            return;
+          }
+        } else {
+          router.push("/");
+          return;
+        }
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [session, router]);
+
+  const submit = async () => {
+    if (!title || !description || !category) return;
+    const payload = {
+      title,
+      description,
+      category,
+      subCategory,
+      difficulty,
+      language,
+      author: user?._id || "",
+      questions: [],
+      tags: [],
+      isPublic,
+      isPremium,
+    };
+    try {
+      const res = await fetch("/api/admin/quizzes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        router.push("/admin/quizzes");
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen w-full mx-auto px-4 pt-2 pb-4 flex items-center justify-center">
+        <div className="w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+      </div>
+    );
+  }
+
+  if (!user?.isAdmin) return null;
+
+  return (
+    <div className="min-h-screen w-full mx-auto px-4 pt-2 pb-4">
+      <div className="flex items-center gap-3 mb-6">
+        <h1 className="text-3xl font-bold">Create Quiz</h1>
+        <div className="bg-purple-600 text-white flex items-center gap-1 px-2 py-1 rounded-md">
+          <ShieldCheck className="h-4 w-4" />
+          <span>Admin Access</span>
+        </div>
+      </div>
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Quiz Details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input placeholder="Title" value={title} onChange={(e) => setTitle(e.target.value)} />
+          <Textarea placeholder="Description" value={description} onChange={(e) => setDescription(e.target.value)} />
+          <Input placeholder="Category" value={category} onChange={(e) => setCategory(e.target.value)} />
+          <Input placeholder="Sub Category" value={subCategory} onChange={(e) => setSubCategory(e.target.value)} />
+          <Input placeholder="Language" value={language} onChange={(e) => setLanguage(e.target.value)} />
+          <select value={difficulty} onChange={(e) => setDifficulty(e.target.value)} className="border rounded p-2 w-full">
+            <option value="beginner">Beginner</option>
+            <option value="intermediate">Intermediate</option>
+            <option value="advanced">Advanced</option>
+          </select>
+          <div className="flex items-center gap-2">
+            <Checkbox id="public" checked={isPublic} onCheckedChange={(v) => setIsPublic(!!v)} />
+            <label htmlFor="public">Public</label>
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox id="premium" checked={isPremium} onCheckedChange={(v) => setIsPremium(!!v)} />
+            <label htmlFor="premium">Premium</label>
+          </div>
+          <Button onClick={submit}>Create</Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/[lng]/admin/quizzes/edit/[quizId]/page.tsx
+++ b/app/[lng]/admin/quizzes/edit/[quizId]/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter, useParams } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "../../../../../../components/ui/card";
+import { Button } from "../../../../../../components/ui/button";
+import { Input } from "../../../../../../components/ui/input";
+import { Textarea } from "../../../../../../components/ui/textarea";
+import { Checkbox } from "../../../../../../components/ui/checkbox";
+import { ShieldCheck } from "lucide-react";
+
+interface User { isAdmin: boolean }
+
+export default function EditQuiz() {
+  const { data: session } = useSession();
+  const router = useRouter();
+  const params = useParams();
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [category, setCategory] = useState("");
+  const [subCategory, setSubCategory] = useState("");
+  const [difficulty, setDifficulty] = useState("beginner");
+  const [language, setLanguage] = useState("en");
+  const [isPublic, setIsPublic] = useState(true);
+  const [isPremium, setIsPremium] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!session) {
+        router.push("/api/auth/signin");
+        return;
+      }
+      try {
+        const res = await fetch("/api/user");
+        if (res.ok) {
+          const data = await res.json();
+          setUser(data.user);
+          if (!data.user.isAdmin) {
+            router.push("/");
+            return;
+          }
+        } else {
+          router.push("/");
+          return;
+        }
+        const quizRes = await fetch(`/api/courses?quizId=${params.quizId}`);
+        if (quizRes.ok) {
+          const q = await quizRes.json();
+          if (q.quiz) {
+            setTitle(q.quiz.title);
+            setDescription(q.quiz.description);
+            setCategory(q.quiz.category);
+            setSubCategory(q.quiz.subCategory);
+            setDifficulty(q.quiz.difficulty);
+            setLanguage(q.quiz.language);
+            setIsPublic(q.quiz.isPublic);
+            setIsPremium(q.quiz.isPremium);
+          }
+        }
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [session, router, params.quizId]);
+
+  const submit = async () => {
+    if (!title || !description || !category) return;
+    const payload = { title, description, category, subCategory, difficulty, language, isPublic, isPremium };
+    try {
+      const res = await fetch(`/api/admin/quizzes/${params.quizId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        router.push("/admin/quizzes");
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen w-full mx-auto px-4 pt-2 pb-4 flex items-center justify-center">
+        <div className="w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+      </div>
+    );
+  }
+
+  if (!user?.isAdmin) return null;
+
+  return (
+    <div className="min-h-screen w-full mx-auto px-4 pt-2 pb-4">
+      <div className="flex items-center gap-3 mb-6">
+        <h1 className="text-3xl font-bold">Edit Quiz</h1>
+        <div className="bg-purple-600 text-white flex items-center gap-1 px-2 py-1 rounded-md">
+          <ShieldCheck className="h-4 w-4" />
+          <span>Admin Access</span>
+        </div>
+      </div>
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Quiz Details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input placeholder="Title" value={title} onChange={(e) => setTitle(e.target.value)} />
+          <Textarea placeholder="Description" value={description} onChange={(e) => setDescription(e.target.value)} />
+          <Input placeholder="Category" value={category} onChange={(e) => setCategory(e.target.value)} />
+          <Input placeholder="Sub Category" value={subCategory} onChange={(e) => setSubCategory(e.target.value)} />
+          <Input placeholder="Language" value={language} onChange={(e) => setLanguage(e.target.value)} />
+          <select value={difficulty} onChange={(e) => setDifficulty(e.target.value)} className="border rounded p-2 w-full">
+            <option value="beginner">Beginner</option>
+            <option value="intermediate">Intermediate</option>
+            <option value="advanced">Advanced</option>
+          </select>
+          <div className="flex items-center gap-2">
+            <Checkbox id="public" checked={isPublic} onCheckedChange={(v) => setIsPublic(!!v)} />
+            <label htmlFor="public">Public</label>
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox id="premium" checked={isPremium} onCheckedChange={(v) => setIsPremium(!!v)} />
+            <label htmlFor="premium">Premium</label>
+          </div>
+          <Button onClick={submit}>Save</Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/[lng]/admin/quizzes/page.tsx
+++ b/app/[lng]/admin/quizzes/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "../../../../components/ui/card";
+import { Button } from "../../../../components/ui/button";
+import { ShieldCheck, Trash2, Pencil } from "lucide-react";
+
+interface Quiz {
+  _id: string;
+  title: string;
+  category: string;
+  isPremium: boolean;
+  isPublic: boolean;
+}
+
+interface User { isAdmin: boolean }
+
+export default function ManageQuizzes() {
+  const { data: session } = useSession();
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [quizzes, setQuizzes] = useState<Quiz[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!session) {
+        router.push("/api/auth/signin");
+        return;
+      }
+      try {
+        const userRes = await fetch("/api/user");
+        if (userRes.ok) {
+          const data = await userRes.json();
+          setUser(data.user);
+          if (!data.user.isAdmin) {
+            router.push("/");
+            return;
+          }
+        } else {
+          router.push("/");
+          return;
+        }
+        const res = await fetch("/api/admin/quizzes");
+        if (res.ok) {
+          const data = await res.json();
+          setQuizzes(data.quizzes);
+        }
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [session, router]);
+
+  const deleteQuiz = async (id: string) => {
+    if (!confirm("Delete this quiz?")) return;
+    try {
+      const res = await fetch(`/api/admin/quizzes/${id}`, { method: "DELETE" });
+      if (res.ok) {
+        setQuizzes(quizzes.filter((q) => q._id !== id));
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen w-full mx-auto px-4 pt-2 pb-4 flex items-center justify-center">
+        <div className="w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+      </div>
+    );
+  }
+
+  if (!user?.isAdmin) return null;
+
+  return (
+    <div className="min-h-screen w-full mx-auto px-4 pt-2 pb-4">
+      <div className="flex items-center gap-3 mb-6">
+        <h1 className="text-3xl font-bold">Manage Quizzes</h1>
+        <div className="bg-purple-600 text-white flex items-center gap-1 px-2 py-1 rounded-md">
+          <ShieldCheck className="h-4 w-4" />
+          <span>Admin Access</span>
+        </div>
+      </div>
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Quizzes</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 gap-4">
+            {quizzes.map((quiz) => (
+              <Card key={quiz._id} className="overflow-hidden">
+                <div className="flex items-center p-4 border-b justify-between">
+                  <div>
+                    <h3 className="font-semibold">{quiz.title}</h3>
+                    <p className="text-sm text-gray-500">{quiz.category}</p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button size="sm" variant="outline" onClick={() => router.push(`/admin/quizzes/edit/${quiz._id}`)}>
+                      <Pencil className="h-4 w-4 mr-1" /> Edit
+                    </Button>
+                    <Button size="sm" variant="destructive" onClick={() => deleteQuiz(quiz._id)}>
+                      <Trash2 className="h-4 w-4 mr-1" /> Delete
+                    </Button>
+                  </div>
+                </div>
+              </Card>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+      <div className="flex justify-between">
+        <Button variant="outline" onClick={() => router.push("/admin")}>Back to Dashboard</Button>
+        <Button onClick={() => router.push("/admin/quizzes/create")}>Create New Quiz</Button>
+      </div>
+    </div>
+  );
+}

--- a/app/[lng]/quizzes/page.tsx
+++ b/app/[lng]/quizzes/page.tsx
@@ -14,6 +14,7 @@ interface QuizType {
   difficulty: string
   author: string
   tags: string[]
+  isPremium?: boolean
   studyMaterials?: {
     bibleVerses: { verse: string, text: string}[]
   }
@@ -28,11 +29,15 @@ export default function QuizzesPage() {
   const [category, setCategory] = useState<string>("")
   const [subCategory, setSubCategory] = useState<string>("")
   const [hasStudyMaterials, setHasStudyMaterials] = useState<boolean>(false)
+  interface User { subscribed?: boolean }
+  const [user, setUser] = useState<User | null>(null)
+
+  const isUserSubscribed = user?.subscribed || false
 
   const fetchQuizzes = useCallback(async () => {
     setLoading(true)
     try {
-      const response = await fetch("/api/courses")
+      const response = await fetch("/api/quizzes")
       if (!response.ok) {
         throw new Error("Failed to fetch quizzes")
       }
@@ -45,6 +50,23 @@ export default function QuizzesPage() {
     } finally {
       setLoading(false)
     }
+  }, [])
+
+  // Fetch user data to check subscription status
+  useEffect(() => {
+    const fetchUserData = async () => {
+      try {
+        const response = await fetch("/api/user")
+        if (response.ok) {
+          const data = await response.json()
+          setUser(data.user)
+        }
+      } catch (error) {
+        console.error("Error fetching user data:", error)
+      }
+    }
+
+    fetchUserData()
   }, [])
 
   // Use useCallback to memoize the filterQuizzes function
@@ -71,10 +93,11 @@ export default function QuizzesPage() {
 
   // Handle navigation to quiz detail page
   const handleQuizClick = useCallback(
-    (quizId: string) => {
-      router.push(`/quizzes/${quizId}`)
+    (quiz: QuizType) => {
+      if (quiz.isPremium && !isUserSubscribed) return
+      router.push(`/quizzes/${quiz._id}`)
     },
-    [router],
+    [router, isUserSubscribed],
   )
 
   useEffect(() => {
@@ -151,16 +174,28 @@ export default function QuizzesPage() {
             {filteredQuizzes.map((quiz) => (
               <li
                 key={quiz._id}
-                onClick={() => handleQuizClick(quiz._id)}
-                className="bg-white dark:bg-[#2a2b2f] rounded-lg shadow-lg p-6 overflow-hidden hover:shadow-xl transition-shadow duration-300 cursor-pointer relative"
+                onClick={() => handleQuizClick(quiz)}
+                className={`bg-white dark:bg-[#2a2b2f] rounded-lg shadow-lg p-6 overflow-hidden hover:shadow-xl transition-shadow duration-300 relative ${
+                  quiz.isPremium && !isUserSubscribed ? 'cursor-not-allowed opacity-70' : 'cursor-pointer'
+                }`}
                 role="button"
                 tabIndex={0}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
-                    handleQuizClick(quiz._id)
+                    handleQuizClick(quiz)
                   }
                 }}
               >
+                {quiz.isPremium && (
+                  <div className="absolute top-3 left-3 bg-amber-500 text-white px-2 py-1 rounded-full text-xs">
+                    Premium
+                  </div>
+                )}
+                {quiz.isPremium && !isUserSubscribed && (
+                  <div className="absolute inset-0 flex items-center justify-center bg-black/60 z-10 rounded-lg">
+                    <div className="text-white text-sm font-medium">Premium Content</div>
+                  </div>
+                )}
                 {quiz.studyMaterials?.bibleVerses?.length > 0 && (
                   <div className="absolute top-3 right-3 bg-green-100 text-green-800 px-2 py-1 rounded-full text-xs flex items-center">
                     <BookOpen className="h-3 w-3 mr-1" />

--- a/app/api/admin/quizzes/[quizId]/premium/route.ts
+++ b/app/api/admin/quizzes/[quizId]/premium/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import connectMongoDB from "../../../../../../libs/mongodb";
+import Quiz from "../../../../../../models/Quiz";
+import User from "../../../../../../models/User";
+import { getServerSession } from "next-auth";
+
+export async function POST(req: NextRequest, { params }: { params: { quizId: string } }) {
+  try {
+    const session = await getServerSession();
+    if (!session || !session.user?.email) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+    await connectMongoDB();
+    const user = await User.findOne({ email: session.user.email });
+    if (!user || !user.isAdmin) {
+      return NextResponse.json({ error: "Unauthorized. Admin access required." }, { status: 403 });
+    }
+
+    const { isPremium } = await req.json();
+    if (isPremium === undefined) {
+      return NextResponse.json({ error: "isPremium field is required" }, { status: 400 });
+    }
+
+    const quiz = await Quiz.findById(params.quizId);
+    if (!quiz) {
+      return NextResponse.json({ error: "Quiz not found" }, { status: 404 });
+    }
+
+    quiz.isPremium = isPremium;
+    await quiz.save();
+
+    return NextResponse.json({ message: `Successfully updated quiz premium status to ${isPremium}`, quiz });
+  } catch (error) {
+    console.error("Error updating quiz premium status:", error);
+    return NextResponse.json({ error: "Failed to update quiz premium status" }, { status: 500 });
+  }
+}

--- a/app/api/admin/quizzes/[quizId]/route.ts
+++ b/app/api/admin/quizzes/[quizId]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import connectMongoDB from "../../../../../libs/mongodb";
+import Quiz from "../../../../../models/Quiz";
+import User from "../../../../../models/User";
+import { getServerSession } from "next-auth";
+
+async function verifyAdmin() {
+  const session = await getServerSession();
+  if (!session || !session.user?.email) {
+    return { error: NextResponse.json({ error: "Not authenticated" }, { status: 401 }) };
+  }
+  await connectMongoDB();
+  const user = await User.findOne({ email: session.user.email });
+  if (!user || !user.isAdmin) {
+    return { error: NextResponse.json({ error: "Unauthorized. Admin access required." }, { status: 403 }) };
+  }
+  return { user };
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { quizId: string } }) {
+  const auth = await verifyAdmin();
+  if (auth.error) return auth.error;
+
+  const data = await req.json();
+  try {
+    const quiz = await Quiz.findByIdAndUpdate(params.quizId, data, { new: true });
+    if (!quiz) {
+      return NextResponse.json({ error: "Quiz not found" }, { status: 404 });
+    }
+    return NextResponse.json({ quiz });
+  } catch (error) {
+    console.error("Error updating quiz:", error);
+    return NextResponse.json({ error: "Failed to update quiz" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { quizId: string } }) {
+  const auth = await verifyAdmin();
+  if (auth.error) return auth.error;
+
+  try {
+    await Quiz.findByIdAndDelete(params.quizId);
+    return NextResponse.json({ message: "Quiz deleted" });
+  } catch (error) {
+    console.error("Error deleting quiz:", error);
+    return NextResponse.json({ error: "Failed to delete quiz" }, { status: 500 });
+  }
+}

--- a/app/api/admin/quizzes/route.ts
+++ b/app/api/admin/quizzes/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import connectMongoDB from "../../../../libs/mongodb";
+import Quiz from "../../../../models/Quiz";
+import User from "../../../../models/User";
+import { getServerSession } from "next-auth";
+
+async function verifyAdmin() {
+  const session = await getServerSession();
+  if (!session || !session.user?.email) {
+    return { error: NextResponse.json({ error: "Not authenticated" }, { status: 401 }) };
+  }
+  await connectMongoDB();
+  const user = await User.findOne({ email: session.user.email });
+  if (!user || !user.isAdmin) {
+    return { error: NextResponse.json({ error: "Unauthorized. Admin access required." }, { status: 403 }) };
+  }
+  return { user };
+}
+
+export async function GET() {
+  const auth = await verifyAdmin();
+  if (auth.error) return auth.error;
+
+  const quizzes = await Quiz.find().lean();
+  return NextResponse.json({ quizzes });
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await verifyAdmin();
+  if (auth.error) return auth.error;
+
+  const data = await req.json();
+  try {
+    const quiz = new Quiz(data);
+    await quiz.save();
+    return NextResponse.json({ quiz }, { status: 201 });
+  } catch (error) {
+    console.error("Error creating quiz:", error);
+    return NextResponse.json({ error: "Failed to create quiz" }, { status: 500 });
+  }
+}

--- a/app/api/courses/route.ts
+++ b/app/api/courses/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import connectMongoDB from '../../../libs/mongodb';
 import Course from '../../../models/Course';
 import Quiz from '../../../models/Quiz';
+import { getServerSession } from 'next-auth';
+import User from '../../../models/User';
 
 export async function GET(request: Request) {
   try {
@@ -13,20 +15,42 @@ export async function GET(request: Request) {
     const quizId = searchParams.get('quizId');
 
     if (quizId) {
-      // Use .lean() to get a plain JavaScript object
       const quiz = await Quiz.findById(quizId).lean();
       if (!quiz) {
         return NextResponse.json({ message: 'Quiz not found' }, { status: 404 });
       }
+
+      if (!quiz.isPublic) {
+        const session = await getServerSession();
+        let isAdmin = false;
+        if (session && session.user?.email) {
+          const user = await User.findOne({ email: session.user.email });
+          isAdmin = !!user?.isAdmin;
+        }
+        if (!isAdmin) {
+          return NextResponse.json({ message: 'Quiz not available' }, { status: 403 });
+        }
+      }
+
+      if (quiz.isPremium) {
+        const session = await getServerSession();
+        if (!session || !session.user?.email) {
+          return NextResponse.json({ ...quiz, isPremium: true });
+        }
+        const user = await User.findOne({ email: session.user.email });
+        if (!user || !user.subscribed) {
+          return NextResponse.json({ ...quiz, isPremium: true });
+        }
+      }
+
       return NextResponse.json({ quiz });
     }
 
     // Fetch courses and quizzes as plain objects
     const courses = await Course.find().lean();
-    // console.log('Courses fetched:', courses);
-
-    const quizzes = await Quiz.find().lean();
-    // console.log('Quizzes fetched:', quizzes);
+    const quizzes = await Quiz.find({
+      $or: [{ isPublic: true }, { isPublic: { $exists: false } }],
+    }).lean();
 
     return NextResponse.json({ courses, quizzes });
   } catch (error) {

--- a/app/api/quizzes/route.ts
+++ b/app/api/quizzes/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import connectMongoDB from "../../../libs/mongodb";
+import Quiz from "../../../models/Quiz";
+
+export async function GET() {
+  try {
+    await connectMongoDB();
+    const quizzes = await Quiz.find({
+      $or: [{ isPublic: true }, { isPublic: { $exists: false } }],
+    }).lean();
+    return NextResponse.json({ quizzes });
+  } catch (error) {
+    console.error("Error fetching quizzes:", error);
+    return NextResponse.json(
+      { message: "Error fetching quizzes" },
+      { status: 500 }
+    );
+  }
+}

--- a/models/Quiz.js
+++ b/models/Quiz.js
@@ -31,6 +31,8 @@ const QuizSchema = new mongoose.Schema(
       },
     ],
     tags: [String],
+    isPublic: { type: Boolean, default: true },
+    isPremium: { type: Boolean, default: false },
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now },
   },


### PR DESCRIPTION
## Summary
- include quizzes missing the `isPublic` field when listing
- add a dedicated public quizzes API
- fetch quizzes from the new API on the quizzes page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_686c033da454832b8fc6d672402ff49a